### PR TITLE
Fix cross build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ LDLIBS = -llockdev
 endif
 
 PREFIX ?= /usr/local
+STRIP ?= strip
 INSTALL ?= install
-INSTALL_BIN ?= install -s
+INSTALL_BIN ?= install --strip-program=$(STRIP) -s
 
 all: sterm
 


### PR DESCRIPTION
The cross build environment might not have strip available but is going
to have *CROSS*-strip. This can be provided by STRIP variable and that
should be used in install instead of the default strip.
This mainly affects cross build using Nix.